### PR TITLE
Revision of rand_base()

### DIFF
--- a/Math_quiz.java
+++ b/Math_quiz.java
@@ -142,7 +142,6 @@ class CalcModel extends Observable {
     }
 
 
-    // 基数をランダムで代入する関数
     public void rand_base()
     {
         int qbase = -1, sbase = -1;
@@ -150,7 +149,6 @@ class CalcModel extends Observable {
         int sran = (int) (Math.random() * 3) + 1; // 被り防止のため1足して1 ~ 3
         int bases[] = new int[4]; // 基数を収容する配列
         bases[0] = 2; bases[1] = 8; bases[2] = 10; bases[3] = 16;
-
         qbase = bases[qran];
         sbase = bases[(sran + qran) % 4];
         this.set_base(qbase, sbase);

--- a/Math_quiz.java
+++ b/Math_quiz.java
@@ -1,4 +1,4 @@
-﻿import javax.swing.*;
+import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;
 import java.util.*;
@@ -133,6 +133,7 @@ class CalcModel extends Observable {
         qcount++;
         if (reply.equals(answer)) {
             ccount++;
+
             return correct;
         }
         else {
@@ -140,71 +141,19 @@ class CalcModel extends Observable {
         }
     }
 
+
     // 基数をランダムで代入する関数
     public void rand_base()
     {
         int qbase = -1, sbase = -1;
         int qran = (int) (Math.random() * 4); // 0 ~ 3までの乱数
-        int sran = (int) (Math.random() * 3); // 0 ~ 2までの乱数
+        int sran = (int) (Math.random() * 3) + 1; // 被り防止のため1足して1 ~ 3
+        int bases[] = new int[4]; // 基数を収容する配列
+        bases[0] = 2; bases[1] = 4; bases[2] = 8; bases[3] = 16;
 
-        switch (qran) {
-            case 0:
-                qbase = 2; // 問題の基数: 2進数
-                switch (sran) {
-                    case 0:
-                        sbase = 8; // 答えの基数: 8進数
-                        break;
-                    case 1:
-                        sbase = 10; // 答えの基数: 10進数
-                        break;
-                    case 2:
-                        sbase = 16; // 答えの基数: 16進数
-                        break;
-                }
-                break;
-            case 1:
-                qbase = 8; // 問題の基数: 8進数
-                switch (sran) {
-                    case 0:
-                        sbase = 2; // 答えの基数: 2進数
-                        break;
-                    case 1:
-                        sbase = 10; // 答えの基数: 10進数
-                        break;
-                    case 2:
-                        sbase = 16; // 答えの基数: 16進数
-                        break;
-                }
-                break;
-            case 2:
-                qbase = 10; // 問題の基数: 10進数
-                switch (sran) {
-                    case 0:
-                        sbase = 2; // 答えの基数: 2進数
-                        break;
-                    case 1:
-                        sbase = 8; // 答えの基数: 8進数
-                        break;
-                    case 2:
-                        sbase = 16; // 答えの基数: 16進数
-                        break;
-                }
-                break;
-            case 3:
-                qbase = 16; // 問題の基数: 16進数
-                switch (sran) {
-                    case 0:
-                        sbase = 2; // 答えの基数: 2進数
-                        break;
-                    case 1:
-                        sbase = 8; // 答えの基数: 8進数
-                        break;
-                    case 2:
-                        sbase = 10; // 答えの基数: 10進数
-                        break;
-                }
-                break;
-        }
+        qbase = qbase[qran];
+        sbase = bases[(sran + qran) % 4];
+        
 
         this.set_base(qbase, sbase);
         this.reset();

--- a/Math_quiz.java
+++ b/Math_quiz.java
@@ -117,7 +117,6 @@ class CalcModel extends Observable {
                 answer = hex;
                 break;
         }
-        System.out.println(sol);
     }
 
     public String check_answer()

--- a/Math_quiz.java
+++ b/Math_quiz.java
@@ -117,6 +117,7 @@ class CalcModel extends Observable {
                 answer = hex;
                 break;
         }
+        System.out.println(sol);
     }
 
     public String check_answer()
@@ -149,12 +150,10 @@ class CalcModel extends Observable {
         int qran = (int) (Math.random() * 4); // 0 ~ 3までの乱数
         int sran = (int) (Math.random() * 3) + 1; // 被り防止のため1足して1 ~ 3
         int bases[] = new int[4]; // 基数を収容する配列
-        bases[0] = 2; bases[1] = 4; bases[2] = 8; bases[3] = 16;
+        bases[0] = 2; bases[1] = 8; bases[2] = 10; bases[3] = 16;
 
-        qbase = qbase[qran];
+        qbase = bases[qran];
         sbase = bases[(sran + qran) % 4];
-        
-
         this.set_base(qbase, sbase);
         this.reset();
     }


### PR DESCRIPTION
- もともとのrand_base()ではSwitch文で出題基数を決定していた
    - わかりやすいが、行数を消費するため冗長になってしまう

- 配列を使用して行数を節約
    - 基数が被らないように調整してある

- 文字コードの調整